### PR TITLE
Add Firefox container and Facebook container support

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,6 +9,12 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
       sbPrevUrl = request.data.url;
       return tab.id;
     });
+  } else if (request.type === 'share-backid-container') {
+    browser.tabs.create(request.data).then(function(tab) {
+      sbId = tab.id;
+      sbPrevUrl = request.data.url;
+      return tab.id;
+    });
   }
 });
 // Autoclose the window when the url change

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,9 @@
     "permissions": [
         "tabs",
         "storage",
+        "cookies",
+        "management",
+        "contextualIdentities",
         "https://www.linkedin.com/*",
         "https://plus.google.com/*",
         "https://reddit.com/*"


### PR DESCRIPTION
this patch checks whether a share URL is assigned to a container or Facebook container extension is enabled, then open that URL in new container tab since [`windows.create()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/windows/create) API didn't have `cookieStoreId` option.