### PR TITLE
Added missing double quotes in Bluesky

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -451,7 +451,7 @@
                 <label><input type="number" id="bluesky-height" value="340" class="heights"></label>
             </div>
             <div class="col-3">
-                <label><input type="number" id="bluesky-priority" value="30 min="1" step="1" class="positions"><button type="button" id="bluesky-move-up" class="move-up"></button><button type="button" id="bluesky-move-down" class="move-down"></button></label>
+                <label><input type="number" id="bluesky-priority" value="30" min="1" step="1" class="positions"><button type="button" id="bluesky-move-up" class="move-up"></button><button type="button" id="bluesky-move-down" class="move-down"></button></label>
             </div>
         </div>
         <div class="row service">


### PR DESCRIPTION
The value attribute for id="bluesky-priority" was missing double quotes.
This fix adds the missing double quotes.