### PR TITLE
Fix wrong id for Bluesky

### DIFF
--- a/modal/modal.html
+++ b/modal/modal.html
@@ -153,7 +153,7 @@
             <img src="icons/threads.png" alt="Facebook" title="Facebook" />
         </button>
 
-        <button class="col share clearfix" id="threads"
+        <button class="col share clearfix" id="bluesky"
                 data-share="https://bsky.app/intent/compose?text">
             <img src="icons/bluesky.svg" alt="Bluesky" title="Bluesky" />
         </button>

--- a/options/options.html
+++ b/options/options.html
@@ -451,7 +451,7 @@
                 <label><input type="number" id="bluesky-height" value="340" class="heights"></label>
             </div>
             <div class="col-3">
-                <label><input type="number" id="bluesky-priority" value="30 min="1" step="1" class="positions"><button type="button" id="bluesky-move-up" class="move-up"></button><button type="button" id="bluesky-move-down" class="move-down"></button></label>
+                <label><input type="number" id="bluesky-priority" value="30" min="1" step="1" class="positions"><button type="button" id="bluesky-move-up" class="move-up"></button><button type="button" id="bluesky-move-down" class="move-down"></button></label>
             </div>
         </div>
         <div class="row service">


### PR DESCRIPTION
This is the real reason why the Bluesky icon disappears when the position of Bluesky is changed (e.g. from 30 to 1) ,which I mentioned in https://github.com/Mte90/Share-Backported/issues/192#issuecomment-2620785120.